### PR TITLE
New Artisan commands to assist with contribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ You must have the `app.debug` config option set to true for these commands to be
 
 #### Missing Command
 
-This command is to assist contributors to find any untranslated keys for their chosen language. A stub JSON file will be created at `storage_path('app/nova-lang/missing/{locale}.json')`. You can copy those keys into the `resources/lang/{locale}.json` language file in your own fork of the repository, translate them and create a pull request.
+This command is to assist contributors to find any untranslated keys for their chosen language.
+
+A stub JSON file will be created at `storage_path('app/nova-lang/missing/{locale}.json')`. You can copy those keys into the `resources/lang/{locale}.json` language file in your own fork of the repository, translate them and create a pull request.
 
 Output missing translation keys for one or more languages:
 ```bash
@@ -52,7 +54,9 @@ php artisan nova-lang:missing --all
 
 #### Stats Command
 
-This command is to assist maintainers to record the completeness of each language and contributors. A `README.excerpt.md` and `contributors.json` file will be created at `storage_path('app/nova-lang')`. You can copy those files into your own fork of the repository and create a pull request.
+This command is to assist maintainers to update the completeness of each language and list of contributors in this README file.
+
+A `README.excerpt.md` and `contributors.json` file will be created at `storage_path('app/nova-lang')`. You can copy those files into your own fork of the repository and create a pull request.
 
 Output list of languages, lines translated and contributors:
 ```bash

--- a/README.md
+++ b/README.md
@@ -31,9 +31,14 @@ Publish translations and override existing files:
 ```bash
 php artisan nova-lang:publish de,ru --force
 ```
-### Missing Command
 
-This command is to assist contributors to find any untranslated keys for their chosen language. A stub JSON file will be created at `storage_path('app/nova-lang/{locale}.missing.json')`. You can copy the keys into the language file in your own fork of the repository, translate them and create a pull request.
+### Development Commands (debug mode only)
+
+You must have the `app.debug` config option set to true for these commands to be available:
+
+#### Missing Command
+
+This command is to assist contributors to find any untranslated keys for their chosen language. A stub JSON file will be created at `storage_path('app/nova-lang/missing/{locale}.json')`. You can copy those keys into the `resources/lang/{locale}.json` language file in your own fork of the repository, translate them and create a pull request.
 
 Output missing translation keys for one or more languages:
 ```bash
@@ -45,43 +50,52 @@ Output missing translation keys for all languages:
 php artisan nova-lang:missing --all
 ```
 
+#### Stats Command
+
+This command is to assist maintainers to record the completeness of each language and contributors. A `README.excerpt.md` and `contributors.json` file will be created at `storage_path('app/nova-lang')`. You can copy those files into your own fork of the repository and create a pull request.
+
+Output list of languages, lines translated and contributors:
+```bash
+php artisan nova-lang:stats
+```
+
 ## Available Languages
 
-| Language | Code | Status | Thanks to |
+| Language | Code | Lines translated | Thanks to |
 | --- | --- | --- | --- |
-| English | en | completed | [taylorotwell](https://github.com/taylorotwell) |
-| Russian | ru | completed | [hivokas](https://github.com/hivokas), [estim](https://github.com/estim), [deadem](https://github.com/deadem), [Sanasol](https://github.com/S-anasol) |
-| German | de | completed | [pille1842](https://github.com/pille1842), [dakira](https://github.com/dakira) |
-| Dutch | nl | completed | [happyDemon](https://github.com/happyDemon), [sebastiaanspeck](https://github.com/sebastiaanspeck), [jschram](https://github.com/jschram) |
-| Turkish | tr | completed | [bureken](https://github.com/bureken), [dilekuzulmez](https://github.com/dilekuzulmez) |
-| Ukrainian | uk | completed | [coderello](https://github.com/coderello) |
-| Arabic | ar | completed | [saleem-hadad](https://github.com/saleem-hadad), [Arryan](https://github.com/Arryan) |
-| Spanish | es | completed | [ajmariduena](https://github.com/ajmariduena), [Arryan](https://github.com/Arryan), [xcodinas](https://github.com/xcodinas), [joebordes](https://github.com/joebordes), [rodrigore](https://github.com/rodrigore) |
-| French | fr | completed | [Marceau Ka](https://github.com/MarceauKa), [Arryan](https://github.com/Arryan) |
-| Polish | pl | completed | [Strus](https://github.com/Strus), [marekfilip](https://github.com/marekfilip), [wiktor-k](https://github.com/wiktor-k) |
-| Persian | fa | completed | [mziraki](https://github.com/mziraki), [alirezamirsepassi](https://github.com/alirezamirsepassi)|
-| Chinese (Simplified) | zh-CN | completed | [jcc](https://github.com/jcc) |
-| Romanian | ro | completed | [BTeodorWork](https://github.com/BTeodorWork), [alexgiuvara](https://github.com/alexgiuvara) |
-| Chinese | cn | completed | [Pierolin](https://github.com/Pierolin) |
-| Chinese (Taiwan) | zh-TW | completed | [CasperLaiTW](https://github.com/CasperLaiTW) |
-| Georgian | ka | completed | [akalongman](https://github.com/akalongman) |
-| Swedish | sv | completed | [tanjemark](https://github.com/tanjemark) |
-| Brazilian Portuguese | pt-BR | completed | [eduardokum](https://github.com/eduardokum), [chbbc](https://github.com/chbbc) |
-| Italian | it | completed | [dejdav](https://github.com/dejdav), [manuelcoppotelli](https://github.com/manuelcoppotelli) |
-| Indonesian | id | completed | [dvlwj](https://github.com/dvlwj) |
-| Hungarian | hu | completed | [milli05](https://github.com/milli05) |
-| Danish | da | completed | [olivernybroe](https://github.com/olivernybroe) |
-| Serbian | sr | completed | [marjanovicsteva](https://github.com/marjanovicsteva) |
-| Filipino | fil | completed | [granaderos](https://github.com/granaderos) |
-| Portuguese | pt | completed | [Pedrocssg](https://github.com/Pedrocssg) |
-| Basque | eu | completed | [JonPaternain](https://github.com/JonPaternain) |
-| Finnish | fi | completed | [Krisseck](https://github.com/Krisseck) |
-| Lithuanian | lt | completed | [minved](https://github.com/minved) |
-| Hindi | hi | completed | [bantya](https://github.com/bantya) |
-| Bulgarian | bg | completed | [BKirev](https://github.com/BKirev) |
-| Slovenian | sl | completed | [morpheus7CS](https://github.com/morpheus7CS) |
-| Slovak | sk | completed | [hejty](https://github.com/hejty) |
-| Czech | cs | completed | [walaski](https://github.com/walaskir) |
-| Croatian | hr | completed | [walaski](https://github.com/defart) |
-| Catalan | ca | completed | [joebordes](https://github.com/joebordes) |
-| Tagalog | tl | completed | [rcjavier](https://github.com/rcjavier) |
+| French | fr | 383 (99%) | [Arryan](https://github.com/Arryan), [MarceauKa](https://github.com/MarceauKa) |
+| English | en | 374 (96.6%) | [taylorotwell](https://github.com/taylorotwell), [bonzai](https://github.com/bonzai), [davidhemphill](https://github.com/davidhemphill), [themsaid](https://github.com/themsaid) |
+| Farsi | fa | 374 (96.6%) | [mziraki](https://github.com/mziraki) |
+| Brazilian Portuguese | pt-BR | 372 (96.1%) | [chbbc](https://github.com/chbbc), [eduardokum](https://github.com/eduardokum) |
+| Russian | ru | 366 (94.6%) | [Sanasol](https://github.com/Sanasol), [deadem](https://github.com/deadem), [estim](https://github.com/estim), [hivokas](https://github.com/hivokas) |
+| German | de | 362 (93.5%) | [dakira](https://github.com/dakira), [pille1842](https://github.com/pille1842) |
+| Spanish | es | 340 (87.9%) | [Arryan](https://github.com/Arryan), [ajmariduena](https://github.com/ajmariduena), [joebordes](https://github.com/joebordes), [rodrigore](https://github.com/rodrigore), [xcodinas](https://github.com/xcodinas) |
+| Slovenian | sl | 338 (87.3%) | [morpheus7CS](https://github.com/morpheus7CS) |
+| Bulgarian | bg | 338 (87.3%) | [BKirev](https://github.com/BKirev) |
+| Croatian | hr | 338 (87.3%) | [walaski](https://github.com/walaski) |
+| Danish | da | 338 (87.3%) | [olivernybroe](https://github.com/olivernybroe) |
+| Catalan | ca | 338 (87.3%) | [joebordes](https://github.com/joebordes) |
+| Lithuanian | lt | 338 (87.3%) | [minved](https://github.com/minved) |
+| Finnish | fi | 338 (87.3%) | [Krisseck](https://github.com/Krisseck) |
+| Basque | eu | 338 (87.3%) | [JonPaternain](https://github.com/JonPaternain) |
+| Portuguese | pt | 338 (87.3%) | [Pedrocssg](https://github.com/Pedrocssg) |
+| Filipino | fil | 338 (87.3%) | [granaderos](https://github.com/granaderos) |
+| Serbian | sr | 338 (87.3%) | [marjanovicsteva](https://github.com/marjanovicsteva) |
+| Hindi | hi | 338 (87.3%) | [bantya](https://github.com/bantya) |
+| Italian | it | 338 (87.3%) | [dejdav](https://github.com/dejdav), [manuelcoppotelli](https://github.com/manuelcoppotelli) |
+| Hungarian | hu | 338 (87.3%) | [milli05](https://github.com/milli05) |
+| Indonesian | id | 338 (87.3%) | [dvlwj](https://github.com/dvlwj) |
+| Swedish | sv | 338 (87.3%) | [tanjemark](https://github.com/tanjemark) |
+| Georgian | ka | 338 (87.3%) | [akalongman](https://github.com/akalongman) |
+| Arabic | ar | 338 (87.3%) | [Arryan](https://github.com/Arryan), [saleem-hadad](https://github.com/saleem-hadad) |
+| Ukrainian | uk | 338 (87.3%) | [coderello](https://github.com/coderello) |
+| Tagalog | tl | 338 (87.3%) | [rcjavier](https://github.com/rcjavier) |
+| Slovak | sk | 337 (87.1%) | [hejty](https://github.com/hejty) |
+| Chinese (Traditional) | zh-TW | 336 (86.8%) | [CasperLaiTW](https://github.com/CasperLaiTW) |
+| Chinese | cn | 336 (86.8%) | [Pierolin](https://github.com/Pierolin) |
+| Romanian | ro | 336 (86.8%) | [BTeodorWork](https://github.com/BTeodorWork), [alexgiuvara](https://github.com/alexgiuvara) |
+| Chinese (Simplified) | zh-CN | 336 (86.8%) | [jcc](https://github.com/jcc) |
+| Polish | pl | 336 (86.8%) | [Strus](https://github.com/Strus), [marekfilip](https://github.com/marekfilip), [wiktor-k](https://github.com/wiktor-k) |
+| Czech | cs | 336 (86.8%) | [walaski](https://github.com/walaski) |
+| Turkish | tr | 336 (86.8%) | [bureken](https://github.com/bureken), [dilekuzulmez](https://github.com/dilekuzulmez) |
+| Dutch | nl | 336 (86.8%) | [happyDemon](https://github.com/happyDemon), [jschram](https://github.com/jschram), [sebastiaanspeck](https://github.com/sebastiaanspeck) |

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ composer require coderello/laravel-nova-lang
 ```
 
 ## Usage
-
+### Publish Command
 Publish translations for one language:
 ```bash
 php artisan nova-lang:publish de
@@ -22,9 +22,27 @@ Publish translations for multiple languages:
 php artisan nova-lang:publish de,ru
 ```
 
-Publish translations with overriding of existing ones:
+Publish translations for all languages:
+```bash
+php artisan nova-lang:publish --all
+```
+
+Publish translations and override existing files:
 ```bash
 php artisan nova-lang:publish de,ru --force
+```
+### Missing Command
+
+This command is to assist contributors to find any untranslated keys for their chosen language. A stub JSON file will be created at `storage_path('app/nova-lang/{locale}.missing.json')`. You can copy the keys into the language file in your own fork of the repository, translate them and create a pull request.
+
+Output missing translation keys for one or more languages:
+```bash
+php artisan nova-lang:missing de,ru
+```
+
+Output missing translation keys for all languages:
+```bash
+php artisan nova-lang:missing --all
 ```
 
 ## Available Languages

--- a/README.md
+++ b/README.md
@@ -68,38 +68,38 @@ php artisan nova-lang:stats
 | Language | Code | Lines translated | Thanks to |
 | --- | --- | --- | --- |
 | French | [fr](resources/lang/fr.json) | 383 (99%) | [Arryan](https://github.com/Arryan), [MarceauKa](https://github.com/MarceauKa) |
-| Farsi | [fa](resources/lang/fa.json) | 374 (96.6%) | [mziraki](https://github.com/mziraki) |
 | English | [en](resources/lang/en.json) | 374 (96.6%) | [taylorotwell](https://github.com/taylorotwell), [bonzai](https://github.com/bonzai), [davidhemphill](https://github.com/davidhemphill), [themsaid](https://github.com/themsaid) |
+| Farsi | [fa](resources/lang/fa.json) | 374 (96.6%) | [mziraki](https://github.com/mziraki) |
 | Brazilian Portuguese | [pt-BR](resources/lang/pt-BR.json) | 372 (96.1%) | [chbbc](https://github.com/chbbc), [eduardokum](https://github.com/eduardokum) |
 | Russian | [ru](resources/lang/ru.json) | 366 (94.6%) | [Sanasol](https://github.com/Sanasol), [deadem](https://github.com/deadem), [estim](https://github.com/estim), [hivokas](https://github.com/hivokas) |
 | German | [de](resources/lang/de.json) | 362 (93.5%) | [dakira](https://github.com/dakira), [pille1842](https://github.com/pille1842) |
 | Spanish | [es](resources/lang/es.json) | 340 (87.9%) | [Arryan](https://github.com/Arryan), [ajmariduena](https://github.com/ajmariduena), [joebordes](https://github.com/joebordes), [rodrigore](https://github.com/rodrigore), [xcodinas](https://github.com/xcodinas) |
+| Arabic | [ar](resources/lang/ar.json) | 338 (87.3%) | [Arryan](https://github.com/Arryan), [saleem-hadad](https://github.com/saleem-hadad) |
+| Basque | [eu](resources/lang/eu.json) | 338 (87.3%) | [JonPaternain](https://github.com/JonPaternain) |
+| Bulgarian | [bg](resources/lang/bg.json) | 338 (87.3%) | [BKirev](https://github.com/BKirev) |
+| Catalan | [ca](resources/lang/ca.json) | 338 (87.3%) | [joebordes](https://github.com/joebordes) |
+| Croatian | [hr](resources/lang/hr.json) | 338 (87.3%) | [walaski](https://github.com/walaski) |
+| Danish | [da](resources/lang/da.json) | 338 (87.3%) | [olivernybroe](https://github.com/olivernybroe) |
+| Filipino | [fil](resources/lang/fil.json) | 338 (87.3%) | [granaderos](https://github.com/granaderos) |
+| Finnish | [fi](resources/lang/fi.json) | 338 (87.3%) | [Krisseck](https://github.com/Krisseck) |
+| Georgian | [ka](resources/lang/ka.json) | 338 (87.3%) | [akalongman](https://github.com/akalongman) |
+| Hindi | [hi](resources/lang/hi.json) | 338 (87.3%) | [bantya](https://github.com/bantya) |
+| Hungarian | [hu](resources/lang/hu.json) | 338 (87.3%) | [milli05](https://github.com/milli05) |
+| Indonesian | [id](resources/lang/id.json) | 338 (87.3%) | [dvlwj](https://github.com/dvlwj) |
+| Italian | [it](resources/lang/it.json) | 338 (87.3%) | [dejdav](https://github.com/dejdav), [manuelcoppotelli](https://github.com/manuelcoppotelli) |
+| Lithuanian | [lt](resources/lang/lt.json) | 338 (87.3%) | [minved](https://github.com/minved) |
+| Portuguese | [pt](resources/lang/pt.json) | 338 (87.3%) | [Pedrocssg](https://github.com/Pedrocssg) |
 | Serbian | [sr](resources/lang/sr.json) | 338 (87.3%) | [marjanovicsteva](https://github.com/marjanovicsteva) |
+| Slovenian | [sl](resources/lang/sl.json) | 338 (87.3%) | [morpheus7CS](https://github.com/morpheus7CS) |
+| Swedish | [sv](resources/lang/sv.json) | 338 (87.3%) | [tanjemark](https://github.com/tanjemark) |
 | Tagalog | [tl](resources/lang/tl.json) | 338 (87.3%) | [rcjavier](https://github.com/rcjavier) |
 | Ukrainian | [uk](resources/lang/uk.json) | 338 (87.3%) | [coderello](https://github.com/coderello) |
-| Arabic | [ar](resources/lang/ar.json) | 338 (87.3%) | [Arryan](https://github.com/Arryan), [saleem-hadad](https://github.com/saleem-hadad) |
-| Georgian | [ka](resources/lang/ka.json) | 338 (87.3%) | [akalongman](https://github.com/akalongman) |
-| Swedish | [sv](resources/lang/sv.json) | 338 (87.3%) | [tanjemark](https://github.com/tanjemark) |
-| Indonesian | [id](resources/lang/id.json) | 338 (87.3%) | [dvlwj](https://github.com/dvlwj) |
-| Hungarian | [hu](resources/lang/hu.json) | 338 (87.3%) | [milli05](https://github.com/milli05) |
-| Italian | [it](resources/lang/it.json) | 338 (87.3%) | [dejdav](https://github.com/dejdav), [manuelcoppotelli](https://github.com/manuelcoppotelli) |
-| Hindi | [hi](resources/lang/hi.json) | 338 (87.3%) | [bantya](https://github.com/bantya) |
-| Filipino | [fil](resources/lang/fil.json) | 338 (87.3%) | [granaderos](https://github.com/granaderos) |
-| Danish | [da](resources/lang/da.json) | 338 (87.3%) | [olivernybroe](https://github.com/olivernybroe) |
-| Portuguese | [pt](resources/lang/pt.json) | 338 (87.3%) | [Pedrocssg](https://github.com/Pedrocssg) |
-| Bulgarian | [bg](resources/lang/bg.json) | 338 (87.3%) | [BKirev](https://github.com/BKirev) |
-| Croatian | [hr](resources/lang/hr.json) | 338 (87.3%) | [walaski](https://github.com/walaski) |
-| Slovenian | [sl](resources/lang/sl.json) | 338 (87.3%) | [morpheus7CS](https://github.com/morpheus7CS) |
-| Catalan | [ca](resources/lang/ca.json) | 338 (87.3%) | [joebordes](https://github.com/joebordes) |
-| Lithuanian | [lt](resources/lang/lt.json) | 338 (87.3%) | [minved](https://github.com/minved) |
-| Finnish | [fi](resources/lang/fi.json) | 338 (87.3%) | [Krisseck](https://github.com/Krisseck) |
-| Basque | [eu](resources/lang/eu.json) | 338 (87.3%) | [JonPaternain](https://github.com/JonPaternain) |
 | Slovak | [sk](resources/lang/sk.json) | 337 (87.1%) | [hejty](https://github.com/hejty) |
-| Chinese (Traditional) | [zh-TW](resources/lang/zh-TW.json) | 336 (86.8%) | [CasperLaiTW](https://github.com/CasperLaiTW) |
 | Chinese | [cn](resources/lang/cn.json) | 336 (86.8%) | [Pierolin](https://github.com/Pierolin) |
-| Romanian | [ro](resources/lang/ro.json) | 336 (86.8%) | [BTeodorWork](https://github.com/BTeodorWork), [alexgiuvara](https://github.com/alexgiuvara) |
 | Chinese (Simplified) | [zh-CN](resources/lang/zh-CN.json) | 336 (86.8%) | [jcc](https://github.com/jcc) |
-| Polish | [pl](resources/lang/pl.json) | 336 (86.8%) | [Strus](https://github.com/Strus), [marekfilip](https://github.com/marekfilip), [wiktor-k](https://github.com/wiktor-k) |
+| Chinese (Traditional) | [zh-TW](resources/lang/zh-TW.json) | 336 (86.8%) | [CasperLaiTW](https://github.com/CasperLaiTW) |
 | Czech | [cs](resources/lang/cs.json) | 336 (86.8%) | [walaski](https://github.com/walaski) |
-| Turkish | [tr](resources/lang/tr.json) | 336 (86.8%) | [bureken](https://github.com/bureken), [dilekuzulmez](https://github.com/dilekuzulmez) |
 | Dutch | [nl](resources/lang/nl.json) | 336 (86.8%) | [happyDemon](https://github.com/happyDemon), [jschram](https://github.com/jschram), [sebastiaanspeck](https://github.com/sebastiaanspeck) |
+| Polish | [pl](resources/lang/pl.json) | 336 (86.8%) | [Strus](https://github.com/Strus), [marekfilip](https://github.com/marekfilip), [wiktor-k](https://github.com/wiktor-k) |
+| Romanian | [ro](resources/lang/ro.json) | 336 (86.8%) | [BTeodorWork](https://github.com/BTeodorWork), [alexgiuvara](https://github.com/alexgiuvara) |
+| Turkish | [tr](resources/lang/tr.json) | 336 (86.8%) | [bureken](https://github.com/bureken), [dilekuzulmez](https://github.com/dilekuzulmez) |

--- a/README.md
+++ b/README.md
@@ -63,39 +63,39 @@ php artisan nova-lang:stats
 
 | Language | Code | Lines translated | Thanks to |
 | --- | --- | --- | --- |
-| French | fr | 383 (99%) | [Arryan](https://github.com/Arryan), [MarceauKa](https://github.com/MarceauKa) |
-| English | en | 374 (96.6%) | [taylorotwell](https://github.com/taylorotwell), [bonzai](https://github.com/bonzai), [davidhemphill](https://github.com/davidhemphill), [themsaid](https://github.com/themsaid) |
-| Farsi | fa | 374 (96.6%) | [mziraki](https://github.com/mziraki) |
-| Brazilian Portuguese | pt-BR | 372 (96.1%) | [chbbc](https://github.com/chbbc), [eduardokum](https://github.com/eduardokum) |
-| Russian | ru | 366 (94.6%) | [Sanasol](https://github.com/Sanasol), [deadem](https://github.com/deadem), [estim](https://github.com/estim), [hivokas](https://github.com/hivokas) |
-| German | de | 362 (93.5%) | [dakira](https://github.com/dakira), [pille1842](https://github.com/pille1842) |
-| Spanish | es | 340 (87.9%) | [Arryan](https://github.com/Arryan), [ajmariduena](https://github.com/ajmariduena), [joebordes](https://github.com/joebordes), [rodrigore](https://github.com/rodrigore), [xcodinas](https://github.com/xcodinas) |
-| Slovenian | sl | 338 (87.3%) | [morpheus7CS](https://github.com/morpheus7CS) |
-| Bulgarian | bg | 338 (87.3%) | [BKirev](https://github.com/BKirev) |
-| Croatian | hr | 338 (87.3%) | [walaski](https://github.com/walaski) |
-| Danish | da | 338 (87.3%) | [olivernybroe](https://github.com/olivernybroe) |
-| Catalan | ca | 338 (87.3%) | [joebordes](https://github.com/joebordes) |
-| Lithuanian | lt | 338 (87.3%) | [minved](https://github.com/minved) |
-| Finnish | fi | 338 (87.3%) | [Krisseck](https://github.com/Krisseck) |
-| Basque | eu | 338 (87.3%) | [JonPaternain](https://github.com/JonPaternain) |
-| Portuguese | pt | 338 (87.3%) | [Pedrocssg](https://github.com/Pedrocssg) |
-| Filipino | fil | 338 (87.3%) | [granaderos](https://github.com/granaderos) |
-| Serbian | sr | 338 (87.3%) | [marjanovicsteva](https://github.com/marjanovicsteva) |
-| Hindi | hi | 338 (87.3%) | [bantya](https://github.com/bantya) |
-| Italian | it | 338 (87.3%) | [dejdav](https://github.com/dejdav), [manuelcoppotelli](https://github.com/manuelcoppotelli) |
-| Hungarian | hu | 338 (87.3%) | [milli05](https://github.com/milli05) |
-| Indonesian | id | 338 (87.3%) | [dvlwj](https://github.com/dvlwj) |
-| Swedish | sv | 338 (87.3%) | [tanjemark](https://github.com/tanjemark) |
-| Georgian | ka | 338 (87.3%) | [akalongman](https://github.com/akalongman) |
-| Arabic | ar | 338 (87.3%) | [Arryan](https://github.com/Arryan), [saleem-hadad](https://github.com/saleem-hadad) |
-| Ukrainian | uk | 338 (87.3%) | [coderello](https://github.com/coderello) |
-| Tagalog | tl | 338 (87.3%) | [rcjavier](https://github.com/rcjavier) |
-| Slovak | sk | 337 (87.1%) | [hejty](https://github.com/hejty) |
-| Chinese (Traditional) | zh-TW | 336 (86.8%) | [CasperLaiTW](https://github.com/CasperLaiTW) |
-| Chinese | cn | 336 (86.8%) | [Pierolin](https://github.com/Pierolin) |
-| Romanian | ro | 336 (86.8%) | [BTeodorWork](https://github.com/BTeodorWork), [alexgiuvara](https://github.com/alexgiuvara) |
-| Chinese (Simplified) | zh-CN | 336 (86.8%) | [jcc](https://github.com/jcc) |
-| Polish | pl | 336 (86.8%) | [Strus](https://github.com/Strus), [marekfilip](https://github.com/marekfilip), [wiktor-k](https://github.com/wiktor-k) |
-| Czech | cs | 336 (86.8%) | [walaski](https://github.com/walaski) |
-| Turkish | tr | 336 (86.8%) | [bureken](https://github.com/bureken), [dilekuzulmez](https://github.com/dilekuzulmez) |
-| Dutch | nl | 336 (86.8%) | [happyDemon](https://github.com/happyDemon), [jschram](https://github.com/jschram), [sebastiaanspeck](https://github.com/sebastiaanspeck) |
+| French | [fr](resources/lang/fr.json) | 383 (99%) | [Arryan](https://github.com/Arryan), [MarceauKa](https://github.com/MarceauKa) |
+| Farsi | [fa](resources/lang/fa.json) | 374 (96.6%) | [mziraki](https://github.com/mziraki) |
+| English | [en](resources/lang/en.json) | 374 (96.6%) | [taylorotwell](https://github.com/taylorotwell), [bonzai](https://github.com/bonzai), [davidhemphill](https://github.com/davidhemphill), [themsaid](https://github.com/themsaid) |
+| Brazilian Portuguese | [pt-BR](resources/lang/pt-BR.json) | 372 (96.1%) | [chbbc](https://github.com/chbbc), [eduardokum](https://github.com/eduardokum) |
+| Russian | [ru](resources/lang/ru.json) | 366 (94.6%) | [Sanasol](https://github.com/Sanasol), [deadem](https://github.com/deadem), [estim](https://github.com/estim), [hivokas](https://github.com/hivokas) |
+| German | [de](resources/lang/de.json) | 362 (93.5%) | [dakira](https://github.com/dakira), [pille1842](https://github.com/pille1842) |
+| Spanish | [es](resources/lang/es.json) | 340 (87.9%) | [Arryan](https://github.com/Arryan), [ajmariduena](https://github.com/ajmariduena), [joebordes](https://github.com/joebordes), [rodrigore](https://github.com/rodrigore), [xcodinas](https://github.com/xcodinas) |
+| Serbian | [sr](resources/lang/sr.json) | 338 (87.3%) | [marjanovicsteva](https://github.com/marjanovicsteva) |
+| Tagalog | [tl](resources/lang/tl.json) | 338 (87.3%) | [rcjavier](https://github.com/rcjavier) |
+| Ukrainian | [uk](resources/lang/uk.json) | 338 (87.3%) | [coderello](https://github.com/coderello) |
+| Arabic | [ar](resources/lang/ar.json) | 338 (87.3%) | [Arryan](https://github.com/Arryan), [saleem-hadad](https://github.com/saleem-hadad) |
+| Georgian | [ka](resources/lang/ka.json) | 338 (87.3%) | [akalongman](https://github.com/akalongman) |
+| Swedish | [sv](resources/lang/sv.json) | 338 (87.3%) | [tanjemark](https://github.com/tanjemark) |
+| Indonesian | [id](resources/lang/id.json) | 338 (87.3%) | [dvlwj](https://github.com/dvlwj) |
+| Hungarian | [hu](resources/lang/hu.json) | 338 (87.3%) | [milli05](https://github.com/milli05) |
+| Italian | [it](resources/lang/it.json) | 338 (87.3%) | [dejdav](https://github.com/dejdav), [manuelcoppotelli](https://github.com/manuelcoppotelli) |
+| Hindi | [hi](resources/lang/hi.json) | 338 (87.3%) | [bantya](https://github.com/bantya) |
+| Filipino | [fil](resources/lang/fil.json) | 338 (87.3%) | [granaderos](https://github.com/granaderos) |
+| Danish | [da](resources/lang/da.json) | 338 (87.3%) | [olivernybroe](https://github.com/olivernybroe) |
+| Portuguese | [pt](resources/lang/pt.json) | 338 (87.3%) | [Pedrocssg](https://github.com/Pedrocssg) |
+| Bulgarian | [bg](resources/lang/bg.json) | 338 (87.3%) | [BKirev](https://github.com/BKirev) |
+| Croatian | [hr](resources/lang/hr.json) | 338 (87.3%) | [walaski](https://github.com/walaski) |
+| Slovenian | [sl](resources/lang/sl.json) | 338 (87.3%) | [morpheus7CS](https://github.com/morpheus7CS) |
+| Catalan | [ca](resources/lang/ca.json) | 338 (87.3%) | [joebordes](https://github.com/joebordes) |
+| Lithuanian | [lt](resources/lang/lt.json) | 338 (87.3%) | [minved](https://github.com/minved) |
+| Finnish | [fi](resources/lang/fi.json) | 338 (87.3%) | [Krisseck](https://github.com/Krisseck) |
+| Basque | [eu](resources/lang/eu.json) | 338 (87.3%) | [JonPaternain](https://github.com/JonPaternain) |
+| Slovak | [sk](resources/lang/sk.json) | 337 (87.1%) | [hejty](https://github.com/hejty) |
+| Chinese (Traditional) | [zh-TW](resources/lang/zh-TW.json) | 336 (86.8%) | [CasperLaiTW](https://github.com/CasperLaiTW) |
+| Chinese | [cn](resources/lang/cn.json) | 336 (86.8%) | [Pierolin](https://github.com/Pierolin) |
+| Romanian | [ro](resources/lang/ro.json) | 336 (86.8%) | [BTeodorWork](https://github.com/BTeodorWork), [alexgiuvara](https://github.com/alexgiuvara) |
+| Chinese (Simplified) | [zh-CN](resources/lang/zh-CN.json) | 336 (86.8%) | [jcc](https://github.com/jcc) |
+| Polish | [pl](resources/lang/pl.json) | 336 (86.8%) | [Strus](https://github.com/Strus), [marekfilip](https://github.com/marekfilip), [wiktor-k](https://github.com/wiktor-k) |
+| Czech | [cs](resources/lang/cs.json) | 336 (86.8%) | [walaski](https://github.com/walaski) |
+| Turkish | [tr](resources/lang/tr.json) | 336 (86.8%) | [bureken](https://github.com/bureken), [dilekuzulmez](https://github.com/dilekuzulmez) |
+| Dutch | [nl](resources/lang/nl.json) | 336 (86.8%) | [happyDemon](https://github.com/happyDemon), [jschram](https://github.com/jschram), [sebastiaanspeck](https://github.com/sebastiaanspeck) |

--- a/contributors.json
+++ b/contributors.json
@@ -7,13 +7,6 @@
             "MarceauKa": 1
         }
     },
-    "fa": {
-        "name": "Farsi",
-        "complete": 374,
-        "contributors": {
-            "mziraki": 1
-        }
-    },
     "en": {
         "name": "English",
         "complete": 374,
@@ -22,6 +15,13 @@
             "bonzai": 1,
             "davidhemphill": 1,
             "themsaid": 1
+        }
+    },
+    "fa": {
+        "name": "Farsi",
+        "complete": 374,
+        "contributors": {
+            "mziraki": 1
         }
     },
     "pt-BR": {
@@ -61,11 +61,132 @@
             "xcodinas": 1
         }
     },
+    "ar": {
+        "name": "Arabic",
+        "complete": 338,
+        "contributors": {
+            "Arryan": 1,
+            "saleem-hadad": 1
+        }
+    },
+    "eu": {
+        "name": "Basque",
+        "complete": 338,
+        "contributors": {
+            "JonPaternain": 1
+        }
+    },
+    "bg": {
+        "name": "Bulgarian",
+        "complete": 338,
+        "contributors": {
+            "BKirev": 1
+        }
+    },
+    "ca": {
+        "name": "Catalan",
+        "complete": 338,
+        "contributors": {
+            "joebordes": 1
+        }
+    },
+    "hr": {
+        "name": "Croatian",
+        "complete": 338,
+        "contributors": {
+            "walaski": 1
+        }
+    },
+    "da": {
+        "name": "Danish",
+        "complete": 338,
+        "contributors": {
+            "olivernybroe": 1
+        }
+    },
+    "fil": {
+        "name": "Filipino",
+        "complete": 338,
+        "contributors": {
+            "granaderos": 1
+        }
+    },
+    "fi": {
+        "name": "Finnish",
+        "complete": 338,
+        "contributors": {
+            "Krisseck": 1
+        }
+    },
+    "ka": {
+        "name": "Georgian",
+        "complete": 338,
+        "contributors": {
+            "akalongman": 1
+        }
+    },
+    "hi": {
+        "name": "Hindi",
+        "complete": 338,
+        "contributors": {
+            "bantya": 1
+        }
+    },
+    "hu": {
+        "name": "Hungarian",
+        "complete": 338,
+        "contributors": {
+            "milli05": 1
+        }
+    },
+    "id": {
+        "name": "Indonesian",
+        "complete": 338,
+        "contributors": {
+            "dvlwj": 1
+        }
+    },
+    "it": {
+        "name": "Italian",
+        "complete": 338,
+        "contributors": {
+            "dejdav": 1,
+            "manuelcoppotelli": 1
+        }
+    },
+    "lt": {
+        "name": "Lithuanian",
+        "complete": 338,
+        "contributors": {
+            "minved": 1
+        }
+    },
+    "pt": {
+        "name": "Portuguese",
+        "complete": 338,
+        "contributors": {
+            "Pedrocssg": 1
+        }
+    },
     "sr": {
         "name": "Serbian",
         "complete": 338,
         "contributors": {
             "marjanovicsteva": 1
+        }
+    },
+    "sl": {
+        "name": "Slovenian",
+        "complete": 338,
+        "contributors": {
+            "morpheus7CS": 1
+        }
+    },
+    "sv": {
+        "name": "Swedish",
+        "complete": 338,
+        "contributors": {
+            "tanjemark": 1
         }
     },
     "tl": {
@@ -82,139 +203,11 @@
             "coderello": 1
         }
     },
-    "ar": {
-        "name": "Arabic",
-        "complete": 338,
-        "contributors": {
-            "Arryan": 1,
-            "saleem-hadad": 1
-        }
-    },
-    "ka": {
-        "name": "Georgian",
-        "complete": 338,
-        "contributors": {
-            "akalongman": 1
-        }
-    },
-    "sv": {
-        "name": "Swedish",
-        "complete": 338,
-        "contributors": {
-            "tanjemark": 1
-        }
-    },
-    "id": {
-        "name": "Indonesian",
-        "complete": 338,
-        "contributors": {
-            "dvlwj": 1
-        }
-    },
-    "hu": {
-        "name": "Hungarian",
-        "complete": 338,
-        "contributors": {
-            "milli05": 1
-        }
-    },
-    "it": {
-        "name": "Italian",
-        "complete": 338,
-        "contributors": {
-            "dejdav": 1,
-            "manuelcoppotelli": 1
-        }
-    },
-    "hi": {
-        "name": "Hindi",
-        "complete": 338,
-        "contributors": {
-            "bantya": 1
-        }
-    },
-    "fil": {
-        "name": "Filipino",
-        "complete": 338,
-        "contributors": {
-            "granaderos": 1
-        }
-    },
-    "da": {
-        "name": "Danish",
-        "complete": 338,
-        "contributors": {
-            "olivernybroe": 1
-        }
-    },
-    "pt": {
-        "name": "Portuguese",
-        "complete": 338,
-        "contributors": {
-            "Pedrocssg": 1
-        }
-    },
-    "bg": {
-        "name": "Bulgarian",
-        "complete": 338,
-        "contributors": {
-            "BKirev": 1
-        }
-    },
-    "hr": {
-        "name": "Croatian",
-        "complete": 338,
-        "contributors": {
-            "walaski": 1
-        }
-    },
-    "sl": {
-        "name": "Slovenian",
-        "complete": 338,
-        "contributors": {
-            "morpheus7CS": 1
-        }
-    },
-    "ca": {
-        "name": "Catalan",
-        "complete": 338,
-        "contributors": {
-            "joebordes": 1
-        }
-    },
-    "lt": {
-        "name": "Lithuanian",
-        "complete": 338,
-        "contributors": {
-            "minved": 1
-        }
-    },
-    "fi": {
-        "name": "Finnish",
-        "complete": 338,
-        "contributors": {
-            "Krisseck": 1
-        }
-    },
-    "eu": {
-        "name": "Basque",
-        "complete": 338,
-        "contributors": {
-            "JonPaternain": 1
-        }
-    },
     "sk": {
         "name": "Slovak",
         "complete": 337,
         "contributors": {
             "hejty": 1
-        }
-    },
-    "zh-TW": {
-        "name": "Chinese (Traditional)",
-        "complete": 336,
-        "contributors": {
-            "CasperLaiTW": 1
         }
     },
     "cn": {
@@ -224,19 +217,34 @@
             "Pierolin": 1
         }
     },
-    "ro": {
-        "name": "Romanian",
-        "complete": 336,
-        "contributors": {
-            "BTeodorWork": 1,
-            "alexgiuvara": 1
-        }
-    },
     "zh-CN": {
         "name": "Chinese (Simplified)",
         "complete": 336,
         "contributors": {
             "jcc": 1
+        }
+    },
+    "zh-TW": {
+        "name": "Chinese (Traditional)",
+        "complete": 336,
+        "contributors": {
+            "CasperLaiTW": 1
+        }
+    },
+    "cs": {
+        "name": "Czech",
+        "complete": 336,
+        "contributors": {
+            "walaski": 1
+        }
+    },
+    "nl": {
+        "name": "Dutch",
+        "complete": 336,
+        "contributors": {
+            "happyDemon": 1,
+            "jschram": 1,
+            "sebastiaanspeck": 1
         }
     },
     "pl": {
@@ -248,11 +256,12 @@
             "wiktor-k": 1
         }
     },
-    "cs": {
-        "name": "Czech",
+    "ro": {
+        "name": "Romanian",
         "complete": 336,
         "contributors": {
-            "walaski": 1
+            "BTeodorWork": 1,
+            "alexgiuvara": 1
         }
     },
     "tr": {
@@ -261,15 +270,6 @@
         "contributors": {
             "bureken": 1,
             "dilekuzulmez": 1
-        }
-    },
-    "nl": {
-        "name": "Dutch",
-        "complete": 336,
-        "contributors": {
-            "happyDemon": 1,
-            "jschram": 1,
-            "sebastiaanspeck": 1
         }
     }
 }

--- a/contributors.json
+++ b/contributors.json
@@ -7,6 +7,13 @@
             "MarceauKa": 1
         }
     },
+    "fa": {
+        "name": "Farsi",
+        "complete": 374,
+        "contributors": {
+            "mziraki": 1
+        }
+    },
     "en": {
         "name": "English",
         "complete": 374,
@@ -15,13 +22,6 @@
             "bonzai": 1,
             "davidhemphill": 1,
             "themsaid": 1
-        }
-    },
-    "fa": {
-        "name": "Farsi",
-        "complete": 374,
-        "contributors": {
-            "mziraki": 1
         }
     },
     "pt-BR": {
@@ -61,11 +61,97 @@
             "xcodinas": 1
         }
     },
-    "sl": {
-        "name": "Slovenian",
+    "sr": {
+        "name": "Serbian",
         "complete": 338,
         "contributors": {
-            "morpheus7CS": 1
+            "marjanovicsteva": 1
+        }
+    },
+    "tl": {
+        "name": "Tagalog",
+        "complete": 338,
+        "contributors": {
+            "rcjavier": 1
+        }
+    },
+    "uk": {
+        "name": "Ukrainian",
+        "complete": 338,
+        "contributors": {
+            "coderello": 1
+        }
+    },
+    "ar": {
+        "name": "Arabic",
+        "complete": 338,
+        "contributors": {
+            "Arryan": 1,
+            "saleem-hadad": 1
+        }
+    },
+    "ka": {
+        "name": "Georgian",
+        "complete": 338,
+        "contributors": {
+            "akalongman": 1
+        }
+    },
+    "sv": {
+        "name": "Swedish",
+        "complete": 338,
+        "contributors": {
+            "tanjemark": 1
+        }
+    },
+    "id": {
+        "name": "Indonesian",
+        "complete": 338,
+        "contributors": {
+            "dvlwj": 1
+        }
+    },
+    "hu": {
+        "name": "Hungarian",
+        "complete": 338,
+        "contributors": {
+            "milli05": 1
+        }
+    },
+    "it": {
+        "name": "Italian",
+        "complete": 338,
+        "contributors": {
+            "dejdav": 1,
+            "manuelcoppotelli": 1
+        }
+    },
+    "hi": {
+        "name": "Hindi",
+        "complete": 338,
+        "contributors": {
+            "bantya": 1
+        }
+    },
+    "fil": {
+        "name": "Filipino",
+        "complete": 338,
+        "contributors": {
+            "granaderos": 1
+        }
+    },
+    "da": {
+        "name": "Danish",
+        "complete": 338,
+        "contributors": {
+            "olivernybroe": 1
+        }
+    },
+    "pt": {
+        "name": "Portuguese",
+        "complete": 338,
+        "contributors": {
+            "Pedrocssg": 1
         }
     },
     "bg": {
@@ -82,11 +168,11 @@
             "walaski": 1
         }
     },
-    "da": {
-        "name": "Danish",
+    "sl": {
+        "name": "Slovenian",
         "complete": 338,
         "contributors": {
-            "olivernybroe": 1
+            "morpheus7CS": 1
         }
     },
     "ca": {
@@ -115,92 +201,6 @@
         "complete": 338,
         "contributors": {
             "JonPaternain": 1
-        }
-    },
-    "pt": {
-        "name": "Portuguese",
-        "complete": 338,
-        "contributors": {
-            "Pedrocssg": 1
-        }
-    },
-    "fil": {
-        "name": "Filipino",
-        "complete": 338,
-        "contributors": {
-            "granaderos": 1
-        }
-    },
-    "sr": {
-        "name": "Serbian",
-        "complete": 338,
-        "contributors": {
-            "marjanovicsteva": 1
-        }
-    },
-    "hi": {
-        "name": "Hindi",
-        "complete": 338,
-        "contributors": {
-            "bantya": 1
-        }
-    },
-    "it": {
-        "name": "Italian",
-        "complete": 338,
-        "contributors": {
-            "dejdav": 1,
-            "manuelcoppotelli": 1
-        }
-    },
-    "hu": {
-        "name": "Hungarian",
-        "complete": 338,
-        "contributors": {
-            "milli05": 1
-        }
-    },
-    "id": {
-        "name": "Indonesian",
-        "complete": 338,
-        "contributors": {
-            "dvlwj": 1
-        }
-    },
-    "sv": {
-        "name": "Swedish",
-        "complete": 338,
-        "contributors": {
-            "tanjemark": 1
-        }
-    },
-    "ka": {
-        "name": "Georgian",
-        "complete": 338,
-        "contributors": {
-            "akalongman": 1
-        }
-    },
-    "ar": {
-        "name": "Arabic",
-        "complete": 338,
-        "contributors": {
-            "Arryan": 1,
-            "saleem-hadad": 1
-        }
-    },
-    "uk": {
-        "name": "Ukrainian",
-        "complete": 338,
-        "contributors": {
-            "coderello": 1
-        }
-    },
-    "tl": {
-        "name": "Tagalog",
-        "complete": 338,
-        "contributors": {
-            "rcjavier": 1
         }
     },
     "sk": {

--- a/contributors.json
+++ b/contributors.json
@@ -1,0 +1,275 @@
+{
+    "fr": {
+        "name": "French",
+        "complete": 383,
+        "contributors": {
+            "Arryan": 1,
+            "MarceauKa": 1
+        }
+    },
+    "en": {
+        "name": "English",
+        "complete": 374,
+        "contributors": {
+            "taylorotwell": 2,
+            "bonzai": 1,
+            "davidhemphill": 1,
+            "themsaid": 1
+        }
+    },
+    "fa": {
+        "name": "Farsi",
+        "complete": 374,
+        "contributors": {
+            "mziraki": 1
+        }
+    },
+    "pt-BR": {
+        "name": "Brazilian Portuguese",
+        "complete": 372,
+        "contributors": {
+            "chbbc": 1,
+            "eduardokum": 1
+        }
+    },
+    "ru": {
+        "name": "Russian",
+        "complete": 366,
+        "contributors": {
+            "Sanasol": 1,
+            "deadem": 1,
+            "estim": 1,
+            "hivokas": 1
+        }
+    },
+    "de": {
+        "name": "German",
+        "complete": 362,
+        "contributors": {
+            "dakira": 1,
+            "pille1842": 1
+        }
+    },
+    "es": {
+        "name": "Spanish",
+        "complete": 340,
+        "contributors": {
+            "Arryan": 1,
+            "ajmariduena": 1,
+            "joebordes": 1,
+            "rodrigore": 1,
+            "xcodinas": 1
+        }
+    },
+    "sl": {
+        "name": "Slovenian",
+        "complete": 338,
+        "contributors": {
+            "morpheus7CS": 1
+        }
+    },
+    "bg": {
+        "name": "Bulgarian",
+        "complete": 338,
+        "contributors": {
+            "BKirev": 1
+        }
+    },
+    "hr": {
+        "name": "Croatian",
+        "complete": 338,
+        "contributors": {
+            "walaski": 1
+        }
+    },
+    "da": {
+        "name": "Danish",
+        "complete": 338,
+        "contributors": {
+            "olivernybroe": 1
+        }
+    },
+    "ca": {
+        "name": "Catalan",
+        "complete": 338,
+        "contributors": {
+            "joebordes": 1
+        }
+    },
+    "lt": {
+        "name": "Lithuanian",
+        "complete": 338,
+        "contributors": {
+            "minved": 1
+        }
+    },
+    "fi": {
+        "name": "Finnish",
+        "complete": 338,
+        "contributors": {
+            "Krisseck": 1
+        }
+    },
+    "eu": {
+        "name": "Basque",
+        "complete": 338,
+        "contributors": {
+            "JonPaternain": 1
+        }
+    },
+    "pt": {
+        "name": "Portuguese",
+        "complete": 338,
+        "contributors": {
+            "Pedrocssg": 1
+        }
+    },
+    "fil": {
+        "name": "Filipino",
+        "complete": 338,
+        "contributors": {
+            "granaderos": 1
+        }
+    },
+    "sr": {
+        "name": "Serbian",
+        "complete": 338,
+        "contributors": {
+            "marjanovicsteva": 1
+        }
+    },
+    "hi": {
+        "name": "Hindi",
+        "complete": 338,
+        "contributors": {
+            "bantya": 1
+        }
+    },
+    "it": {
+        "name": "Italian",
+        "complete": 338,
+        "contributors": {
+            "dejdav": 1,
+            "manuelcoppotelli": 1
+        }
+    },
+    "hu": {
+        "name": "Hungarian",
+        "complete": 338,
+        "contributors": {
+            "milli05": 1
+        }
+    },
+    "id": {
+        "name": "Indonesian",
+        "complete": 338,
+        "contributors": {
+            "dvlwj": 1
+        }
+    },
+    "sv": {
+        "name": "Swedish",
+        "complete": 338,
+        "contributors": {
+            "tanjemark": 1
+        }
+    },
+    "ka": {
+        "name": "Georgian",
+        "complete": 338,
+        "contributors": {
+            "akalongman": 1
+        }
+    },
+    "ar": {
+        "name": "Arabic",
+        "complete": 338,
+        "contributors": {
+            "Arryan": 1,
+            "saleem-hadad": 1
+        }
+    },
+    "uk": {
+        "name": "Ukrainian",
+        "complete": 338,
+        "contributors": {
+            "coderello": 1
+        }
+    },
+    "tl": {
+        "name": "Tagalog",
+        "complete": 338,
+        "contributors": {
+            "rcjavier": 1
+        }
+    },
+    "sk": {
+        "name": "Slovak",
+        "complete": 337,
+        "contributors": {
+            "hejty": 1
+        }
+    },
+    "zh-TW": {
+        "name": "Chinese (Traditional)",
+        "complete": 336,
+        "contributors": {
+            "CasperLaiTW": 1
+        }
+    },
+    "cn": {
+        "name": "Chinese",
+        "complete": 336,
+        "contributors": {
+            "Pierolin": 1
+        }
+    },
+    "ro": {
+        "name": "Romanian",
+        "complete": 336,
+        "contributors": {
+            "BTeodorWork": 1,
+            "alexgiuvara": 1
+        }
+    },
+    "zh-CN": {
+        "name": "Chinese (Simplified)",
+        "complete": 336,
+        "contributors": {
+            "jcc": 1
+        }
+    },
+    "pl": {
+        "name": "Polish",
+        "complete": 336,
+        "contributors": {
+            "Strus": 1,
+            "marekfilip": 1,
+            "wiktor-k": 1
+        }
+    },
+    "cs": {
+        "name": "Czech",
+        "complete": 336,
+        "contributors": {
+            "walaski": 1
+        }
+    },
+    "tr": {
+        "name": "Turkish",
+        "complete": 336,
+        "contributors": {
+            "bureken": 1,
+            "dilekuzulmez": 1
+        }
+    },
+    "nl": {
+        "name": "Dutch",
+        "complete": 336,
+        "contributors": {
+            "happyDemon": 1,
+            "jschram": 1,
+            "sebastiaanspeck": 1
+        }
+    }
+}

--- a/src/Commands/NovaLangMissing.php
+++ b/src/Commands/NovaLangMissing.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace Coderello\LaravelNovaLang\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Collection;
+use SplFileInfo;
+
+class NovaLangMissing extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'nova-lang:missing
+                            {locales : Comma separated list of languages}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Output missing keys from Laravel Nova language files to storage folder.';
+
+    /**
+     * @var Filesystem
+     */
+    protected $filesystem;
+
+    /**
+     * Create a new command instance.
+     *
+     * @param Filesystem $filesystem
+     */
+    public function __construct(Filesystem $filesystem)
+    {
+        $this->filesystem = $filesystem;
+
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $sourceDirectory = $this->directoryNovaSource().'/en';
+        $sourceFile = $sourceDirectory.'.json';
+        
+        if (!$this->filesystem->exists($sourceDirectory) || !$this->filesystem->exists($sourceFile)) {
+            $this->error('The source language files were not found in the vendor/laravel/nova directory.');
+
+            return;
+        }
+        
+        $outputDirectory = storage_path('app/nova-lang/');
+        $this->filesystem->makeDirectory($outputDirectory, 0777, true, true);
+        
+        $sourceKeys = array_keys(json_decode($this->filesystem->get($sourceFile), true));
+        
+        $availableLocales = $this->getAvailableLocales();
+
+        $this->getRequestedLocales()->each(function (string $locale) use ($availableLocales, $sourceKeys, $outputDirectory) {
+            
+            if (! $availableLocales->contains($locale)) {
+                $this->warn(sprintf('The translation file for [%s] locale does not exist. You could help other people by creating this file and sending a PR :)', $locale));
+
+                if (!$this->confirm(sprintf('Do you wish to create the file for [%s]?', $locale))) {
+                    return;
+                }
+                
+                $missingKeys = $sourceKeys;
+            }
+            else {
+                $inputDirectory = $this->directoryFrom().'/'.$locale;
+
+                $inputFile = $inputDirectory.'.json';
+
+                $localeKeys = array_keys(json_decode($this->filesystem->get($inputFile), true));
+                
+                $localeKeys = array_map(function($key) {
+                    return str_replace('\\\'', '\'', $key);
+                }, $localeKeys);
+                
+                $missingKeys = array_diff($sourceKeys, $localeKeys);
+            }
+            
+            $outputKeys = array_fill_keys($missingKeys, '');
+            
+            $outputFile = $outputDirectory.'/'.$locale.'.missing.json';
+            
+            $this->filesystem->put($outputFile, json_encode($outputKeys, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+            
+            $this->info(sprintf('%d missing translation keys for [%s] locale have been output to [%s].', count($missingKeys), $locale, $outputFile));
+        });
+    }
+
+    protected function getRequestedLocales(): Collection
+    {
+        return collect(explode(',', $this->argument('locales')));
+    }
+
+    protected function getAvailableLocales(): Collection
+    {
+        $localesByDirectories = collect($this->filesystem->directories($this->directoryFrom()))
+            ->map(function (string $path) {
+                return $this->filesystem->name($path);
+            });
+
+        $localesByFiles = collect($this->filesystem->files($this->directoryFrom()))
+            ->map(function (SplFileInfo $splFileInfo) {
+                return str_replace('.'.$splFileInfo->getExtension(), '', $splFileInfo->getFilename());
+            });
+
+        return $localesByDirectories->intersect($localesByFiles)->values();
+    }
+
+    protected function directoryFrom(): string
+    {
+        return base_path('vendor/coderello/laravel-nova-lang/resources/lang');
+    }
+
+    protected function directoryNovaSource(): string
+    {
+        return base_path('vendor/laravel/nova/resources/lang');
+    }
+}

--- a/src/Commands/NovaLangMissing.php
+++ b/src/Commands/NovaLangMissing.php
@@ -49,6 +49,12 @@ class NovaLangMissing extends Command
      */
     public function handle()
     {
+        if (!config('app.debug')) {
+            $this->error('This command will only run in debug mode.');
+
+            return;
+        }
+        
         $sourceDirectory = $this->directoryNovaSource().'/en';
         $sourceFile = $sourceDirectory.'.json';
         

--- a/src/Commands/NovaLangMissing.php
+++ b/src/Commands/NovaLangMissing.php
@@ -58,7 +58,7 @@ class NovaLangMissing extends Command
             return;
         }
         
-        $outputDirectory = storage_path('app/nova-lang');
+        $outputDirectory = storage_path('app/nova-lang/missing');
         $this->filesystem->makeDirectory($outputDirectory, 0777, true, true);
         
         $sourceKeys = array_keys(json_decode($this->filesystem->get($sourceFile), true));
@@ -99,7 +99,7 @@ class NovaLangMissing extends Command
             
             $outputKeys = array_fill_keys($missingKeys, '');
             
-            $outputFile = $outputDirectory.'/'.$locale.'.missing.json';
+            $outputFile = $outputDirectory.'/'.$locale.'.json';
             
             if (count($outputKeys)) {
                 $this->filesystem->put($outputFile, json_encode($outputKeys, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));

--- a/src/Commands/NovaLangPublish.php
+++ b/src/Commands/NovaLangPublish.php
@@ -53,7 +53,7 @@ class NovaLangPublish extends Command
 
         $this->getRequestedLocales()->each(function (string $locale) use ($availableLocales) {
             if (! $availableLocales->contains($locale)) {
-                $this->error(sprintf('Unfortunately, translations for [%s] locale doesn\'t exist. Feel free to send a PR to add them and help other people :)', $locale));
+                $this->error(sprintf('Unfortunately, translations for [%s] locale don\'t exist. Feel free to send a PR to add them and help other people :)', $locale));
 
                 return;
             }

--- a/src/Commands/NovaLangStats.php
+++ b/src/Commands/NovaLangStats.php
@@ -116,7 +116,7 @@ class NovaLangStats extends Command
                 return sprintf('[%s](https://github.com/%s)', $contributor, $contributor);
             }, array_keys($localeStat['contributors'])));
             
-            return sprintf('| %s | %s | %d (%s) | %s |', $localeStat['name'], $locale, $localeStat['complete'], $percent, $contributors);
+            return sprintf('| %s | [%s](resources/lang/%s.json) | %d (%s) | %s |', $localeStat['name'], $locale, $locale, $localeStat['complete'], $percent, $contributors);
         });
                 
         $outputFile = $outputDirectory.'/README.excerpt.md';

--- a/src/Commands/NovaLangStats.php
+++ b/src/Commands/NovaLangStats.php
@@ -47,6 +47,12 @@ class NovaLangStats extends Command
      */
     public function handle()
     {
+        if (!config('app.debug')) {
+            $this->error('This command will only run in debug mode.');
+
+            return;
+        }
+        
         $sourceDirectory = $this->directoryNovaSource().'/en';
         $sourceFile = $sourceDirectory.'.json';
         
@@ -99,7 +105,9 @@ class NovaLangStats extends Command
 
         });
         
-        $contributors = $contributors->sortByDesc('complete');
+        $contributors = $contributors->sort(function($a, $b) {
+            return $a['complete'] === $b['complete'] ? $a['name'] <=> $b['name'] : 0 - ($a['complete'] <=> $b['complete']);
+        });
         
         $outputFile = $outputDirectory.'/contributors.json';
         

--- a/src/Commands/NovaLangStats.php
+++ b/src/Commands/NovaLangStats.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace Coderello\LaravelNovaLang\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Collection;
+use SplFileInfo;
+
+class NovaLangStats extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'nova-lang:stats';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Collect translation completion and contribution stats for documentation.';
+
+    /**
+     * @var Filesystem
+     */
+    protected $filesystem;
+
+    /**
+     * Create a new command instance.
+     *
+     * @param Filesystem $filesystem
+     */
+    public function __construct(Filesystem $filesystem)
+    {
+        $this->filesystem = $filesystem;
+
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $sourceDirectory = $this->directoryNovaSource().'/en';
+        $sourceFile = $sourceDirectory.'.json';
+        
+        if (!$this->filesystem->exists($sourceDirectory) || !$this->filesystem->exists($sourceFile)) {
+            $this->error('The source language files were not found in the vendor/laravel/nova directory.');
+
+            return;
+        }
+        
+        $outputDirectory = storage_path('app/nova-lang');
+        $this->filesystem->makeDirectory($outputDirectory, 0777, true, true);
+        
+        $contributorsFile = __DIR__.'/../../contributors.json';
+        $contributors = collect(json_decode($this->filesystem->get($contributorsFile), true));
+                        
+        $sourceKeys = array_keys(json_decode($this->filesystem->get($sourceFile), true));
+        $sourceCount = count($sourceKeys);
+        
+        $availableLocales = $this->getAvailableLocales();
+        
+        $availableLocales->each(function (string $locale) use ($contributors, $sourceKeys, $sourceCount) {
+            
+            $inputDirectory = $this->directoryFrom().'/'.$locale;
+
+            $inputFile = $inputDirectory.'.json';
+
+            $localeKeys = array_keys(json_decode($this->filesystem->get($inputFile), true));
+
+            $missingKeys = array_diff($sourceKeys, $localeKeys);
+
+            $localeStat = $contributors->get($locale, [
+                'name' => class_exists('Locale') ? Locale::getDisplayName($locale) : $locale,
+                'contributors' => [],
+            ]);
+            
+            $localeStat['complete'] = $sourceCount - count($missingKeys);
+            
+            // TODO: Count contributions using git blame?
+            
+            $localeStat['contributors'] = collect($localeStat['contributors'])
+                ->map(function($lines, $name) {
+                    return compact('lines', 'name');
+                })->sort(function($a, $b) {
+                return $a['lines'] === $b['lines'] ? $a['name'] <=> $b['name'] : 0 - ($a['lines'] <=> $b['lines']);
+            })->map(function($contributor) {
+                return $contributor['lines'];
+            })->all();
+            
+            $contributors->put($locale, $localeStat);
+
+        });
+        
+        $contributors = $contributors->sortByDesc('complete');
+        
+        $outputFile = $outputDirectory.'/contributors.json';
+        
+        $this->filesystem->put($outputFile, json_encode($contributors, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        
+        $this->info(sprintf('Updated "contributors.json" has been output to [%s].', $outputFile));
+        $this->warn('* Replace contributors.json in your fork of the repository with this file.');
+        
+        $contributors->transform(function($localeStat, $locale) use ($sourceCount) {
+            
+            $percent = round(($localeStat['complete'] / $sourceCount) * 100, 1).'%';
+            
+            $contributors = implode(', ', array_map(function($contributor) {
+                return sprintf('[%s](https://github.com/%s)', $contributor, $contributor);
+            }, array_keys($localeStat['contributors'])));
+            
+            return sprintf('| %s | %s | %d (%s) | %s |', $localeStat['name'], $locale, $localeStat['complete'], $percent, $contributors);
+        });
+                
+        $outputFile = $outputDirectory.'/README.excerpt.md';
+        
+        $header = '## Available Languages'.PHP_EOL.PHP_EOL.'| Language | Code | Lines translated | Thanks to |'.PHP_EOL.'| --- | --- | --- | --- |';
+        
+        $this->filesystem->put($outputFile, $header.PHP_EOL.$contributors->join(PHP_EOL));
+        
+        $this->info(sprintf('Updated "README.excerpt.md" has been output to [%s].', $outputFile));
+        $this->warn('* Replace the Available Languages table in README.md in your fork of the repository with the contents of this file.');
+    }
+
+    protected function getAvailableLocales(): Collection
+    {
+        $localesByDirectories = collect($this->filesystem->directories($this->directoryFrom()))
+            ->map(function (string $path) {
+                return $this->filesystem->name($path);
+            });
+
+        $localesByFiles = collect($this->filesystem->files($this->directoryFrom()))
+            ->map(function (SplFileInfo $splFileInfo) {
+                return str_replace('.'.$splFileInfo->getExtension(), '', $splFileInfo->getFilename());
+            });
+
+        return $localesByDirectories->intersect($localesByFiles)->values();
+    }
+
+    protected function directoryFrom(): string
+    {
+        return base_path('vendor/coderello/laravel-nova-lang/resources/lang');
+    }
+
+    protected function directoryNovaSource(): string
+    {
+        return base_path('vendor/laravel/nova/resources/lang');
+    }
+}

--- a/src/Providers/LaravelNovaLangServiceProvider.php
+++ b/src/Providers/LaravelNovaLangServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Coderello\LaravelNovaLang\Providers;
 
 use Coderello\LaravelNovaLang\Commands\NovaLangPublish;
+use Coderello\LaravelNovaLang\Commands\NovaLangMissing;
 use Illuminate\Support\ServiceProvider;
 
 class LaravelNovaLangServiceProvider extends ServiceProvider
@@ -25,8 +26,11 @@ class LaravelNovaLangServiceProvider extends ServiceProvider
     public function register()
     {
         $this->app->singleton('command.publish.nova-lang', NovaLangPublish::class);
+        $this->app->singleton('command.missing.nova-lang', NovaLangMissing::class);
+        
         $this->commands([
             'command.publish.nova-lang',
+            'command.missing.nova-lang',
         ]);
     }
 }

--- a/src/Providers/LaravelNovaLangServiceProvider.php
+++ b/src/Providers/LaravelNovaLangServiceProvider.php
@@ -4,6 +4,7 @@ namespace Coderello\LaravelNovaLang\Providers;
 
 use Coderello\LaravelNovaLang\Commands\NovaLangPublish;
 use Coderello\LaravelNovaLang\Commands\NovaLangMissing;
+use Coderello\LaravelNovaLang\Commands\NovaLangStats;
 use Illuminate\Support\ServiceProvider;
 
 class LaravelNovaLangServiceProvider extends ServiceProvider
@@ -26,11 +27,19 @@ class LaravelNovaLangServiceProvider extends ServiceProvider
     public function register()
     {
         $this->app->singleton('command.publish.nova-lang', NovaLangPublish::class);
-        $this->app->singleton('command.missing.nova-lang', NovaLangMissing::class);
         
         $this->commands([
             'command.publish.nova-lang',
-            'command.missing.nova-lang',
         ]);
+        
+        if (config('app.debug')) {
+            $this->app->singleton('command.missing.nova-lang', NovaLangMissing::class);
+            $this->app->singleton('command.stats.nova-lang', NovaLangStats::class);
+        
+            $this->commands([
+                'command.missing.nova-lang',
+                'command.stats.nova-lang',
+            ]);
+        }
     }
 }


### PR DESCRIPTION
I have added two new Artisan commands, `nova-lang:missing` and `nova-lang:stats`, to assist contributors to maintain missing translation keys. They are documented in `README.md`.

I also added an `--all` option to the `nova-lang:publish` command to publish all available languages.