### PR TITLE
Fix context specific translation

### DIFF
--- a/resources/lang/fr.json
+++ b/resources/lang/fr.json
@@ -83,7 +83,7 @@
     "This image": "Cette image",
     "Update": "Enregistrer",
     "Update & Continue Editing": "Enregistrer et continuer",
-    "View": "Vue",
+    "View": "Voir",
     "We're lost in space. The page you were trying to view does not exist.": "Vous êtes perdu dans l’espace. La page demandée n’existe pas.",
     "Show Content": "Montrer le contenu",
     "Hide Content": "Masquer le contenu",


### PR DESCRIPTION
The translation was wrong for the context where it's used.