### PR TITLE
fix: update misleading translation (de)

### DIFF
--- a/resources/lang/de.json
+++ b/resources/lang/de.json
@@ -373,7 +373,7 @@
     "resources": "Ressourcen",
     "Choose date": "Datum auswählen",
     "The :resource was created!": "Die Ressource :resource wurde erstellt!",
-    "The resource was attached!": "Die Ressource war angekoppelt!",
+    "The resource was attached!": "Die Ressource wurde angekoppelt!",
     "The :resource was updated!": "Die Ressource :resource wurde aktualisiert!",
     "The resource was updated!": "Die Ressource wurde aktualisiert!",
     "The :resource was deleted!": "Die Ressource :resource wurde gelöscht!",


### PR DESCRIPTION
"The resource was attached!" shouldn't be translated as "war", but rather "wurde" to indicate that "it was just attached" rather than "it was attached in the past".

In a similar context in a few lines further down, it is used correctly:
`"The resource was updated!": "Die Ressource wurde aktualisiert!",`